### PR TITLE
Исправлена авторизация в личном кабинете Мегафон. Была ошибка CSRF to…

### DIFF
--- a/mobile_balance/megafon.py
+++ b/mobile_balance/megafon.py
@@ -13,7 +13,7 @@ def get_balance(number, password):
     response = s.get('https://lk.megafon.ru/login/')
     check_status_code(response, 200)
     
-    csrf_token = re.search(r'name=CSRF value="(.*?)"', response.content)
+    csrf_token = re.search(r'name="CSRF" value="(.*?)"', response.content)
     
     if csrf_token is None:
         raise BadResponse('CSRF token not found', response)


### PR DESCRIPTION
Не корректно отрабатывал парсер страницы логина, из-за этого CSRF был пустым и дальнейшая авторизация не проходила.